### PR TITLE
Add TaskReport to ExecutionResult

### DIFF
--- a/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
+++ b/embulk-core/src/main/java/org/embulk/exec/BulkLoader.java
@@ -313,7 +313,8 @@ public class BulkLoader {
                 ignoredExceptions.add(ex);
             }
 
-            return new ExecutionResult(configDiff, false, Collections.unmodifiableList(ignoredExceptions));
+            return new ExecutionResult(configDiff, false, Collections.unmodifiableList(ignoredExceptions),
+                    this.getAllInputTaskReports(), this.getAllOutputTaskReports());
         }
 
         public ExecutionResult buildExecuteResultOfSkippedExecution(ConfigDiff configDiff) {
@@ -322,7 +323,8 @@ public class BulkLoader {
                 ignoredExceptions.add(e);
             }
 
-            return new ExecutionResult(configDiff, true, Collections.unmodifiableList(ignoredExceptions));
+            return new ExecutionResult(configDiff, true, Collections.unmodifiableList(ignoredExceptions),
+                    this.getAllInputTaskReports(), this.getAllOutputTaskReports());
         }
 
         public ResumeState buildResumeState(ExecSessionInternal exec) {

--- a/embulk-core/src/main/java/org/embulk/exec/ExecutionResult.java
+++ b/embulk-core/src/main/java/org/embulk/exec/ExecutionResult.java
@@ -2,16 +2,22 @@ package org.embulk.exec;
 
 import java.util.List;
 import org.embulk.config.ConfigDiff;
+import org.embulk.config.TaskReport;
 
 public class ExecutionResult {
     private final ConfigDiff configDiff;
     private final boolean skipped;
     private final List<Throwable> ignoredExceptions;
+    private final List<TaskReport> inputTaskReports;
+    private final List<TaskReport> outputTaskReports;
 
-    public ExecutionResult(ConfigDiff configDiff, boolean skipped, List<Throwable> ignoredExceptions) {
+    public ExecutionResult(ConfigDiff configDiff,  boolean skipped,  List<Throwable> ignoredExceptions,
+                           List<TaskReport> inputTaskReports,  List<TaskReport> outputTaskReports) {
         this.configDiff = configDiff;
         this.skipped = skipped;
         this.ignoredExceptions = ignoredExceptions;
+        this.inputTaskReports = inputTaskReports;
+        this.outputTaskReports = outputTaskReports;
     }
 
     public ConfigDiff getConfigDiff() {
@@ -24,5 +30,13 @@ public class ExecutionResult {
 
     public List<Throwable> getIgnoredExceptions() {
         return ignoredExceptions;
+    }
+
+    public List<TaskReport> getOutputTaskReports() {
+        return outputTaskReports;
+    }
+
+    public List<TaskReport> getInputTaskReports() {
+        return inputTaskReports;
     }
 }

--- a/embulk-junit4/src/main/java/org/embulk/test/TestingBulkLoader.java
+++ b/embulk-junit4/src/main/java/org/embulk/test/TestingBulkLoader.java
@@ -44,7 +44,7 @@ class TestingBulkLoader extends BulkLoader {
 
         public TestingExecutionResult(ExecutionResult orig,
                 ResumeState resumeState, ExecSessionInternal session) {
-            super(orig.getConfigDiff(), orig.isSkipped(), orig.getIgnoredExceptions());
+            super(orig.getConfigDiff(), orig.isSkipped(), orig.getIgnoredExceptions(), new ArrayList<>(), new ArrayList<>());
             this.inputSchema = resumeState.getInputSchema();
             this.outputSchema = resumeState.getOutputSchema();
             this.inputTaskReports = buildReports(resumeState.getInputTaskReports(), session);


### PR DESCRIPTION
ExecutionResult doesn’t contain TaskReport of Input and Output plugins. This change will add TaskReport to ExecutionResult